### PR TITLE
Group error as well

### DIFF
--- a/awx_collection/plugins/modules/group.py
+++ b/awx_collection/plugins/modules/group.py
@@ -170,10 +170,11 @@ def main():
             id_list.append(sub_obj['id'])
         # Preserve existing objects
         if (preserve_existing_hosts and relationship == 'hosts') or (preserve_existing_children and relationship == 'children'):
-            preserve_existing_check = module.get_all_endpoint(group['related'][relationship])
-            for sub_obj in preserve_existing_check['json']['results']:
-                if 'id' in sub_obj:
-                    id_list.append(sub_obj['id'])
+            if group:
+                preserve_existing_check = module.get_all_endpoint(group['related'][relationship])
+                for sub_obj in preserve_existing_check['json']['results']:
+                    if 'id' in sub_obj:
+                        id_list.append(sub_obj['id'])
         if id_list:
             association_fields[relationship] = id_list
 


### PR DESCRIPTION
If group does not exist, then it fails as well, comes back None for `group`
 